### PR TITLE
persistent volume and port binding cleanup

### DIFF
--- a/labs/lab2/chapter2.md
+++ b/labs/lab2/chapter2.md
@@ -157,7 +157,7 @@ More generally:
 * Place rarely changing statements towards the top of the file. This allows the re-use of cached image layers when rebuilding.
 * Group statements into multi-line statements. This avoids layers that have files needed only for build.
 * Use `LABEL run` instruction to prescribe how the image is to be run.
-* Avoid running applications in the container as root user where possible.
+* Avoid running applications in the container as root user where possible. The final `USER` declaration in the Dockerfile should specify the [user ID (numeric value)](https://docs.openshift.com/container-platform/latest/creating_images/guidelines.html#openshift-specific-guidelines) and not the user name. If the image does not specify a USER, it inherits the USER from the parent image.
 * Use `VOLUME` instruction to create a host mount point for persistent storage.
 
 In the [next lab](../lab3/chapter3.md) we will fix these issues and break the application up into separate services.

--- a/labs/lab3/chapter3.md
+++ b/labs/lab3/chapter3.md
@@ -109,11 +109,11 @@ $ ls -lR wordpress
 
 1. Add a `VOLUME` instruction. This ensures data will be persisted even if the container is lost. However, it won't do anything unless, when running the container, host directories are mapped to the volumes.
 
-        VOLUME /var/lib/mysql /var/log/mariadb /run/mariadb
+        VOLUME /var/lib/mysql
 
-1. Switch to a non-root `USER`.
+1. Switch to a non-root `USER` uid.
 
-        USER mysql
+        USER 27
 
 1. Finish by adding the `CMD` instruction.
 
@@ -150,6 +150,7 @@ Now we'll create the Wordpress Dockerfile. (As before, there is a reference file
         COPY latest.tar.gz /latest.tar.gz
         RUN tar xvzf /latest.tar.gz -C /var/www/html --strip-components=1 && \
             rm /latest.tar.gz && \
+            usermod -u 27 apache && \
             sed -i 's/^Listen 80/Listen 8080/g' /etc/httpd/conf/httpd.conf && \
             APACHE_DIRS="/var/www/html /usr/share/httpd /var/log/httpd /run/httpd" && \
             chown -R apache:0 ${APACHE_DIRS} && \
@@ -161,11 +162,11 @@ Now we'll create the Wordpress Dockerfile. (As before, there is a reference file
 
 1. Add a `VOLUME` instruction. This ensures data will be persisted even if the container is lost.
 
-        VOLUME /var/www/html/wp-content/uploads /var/log/httpd /run/httpd
+        VOLUME /var/www/html/wp-content/uploads
 
-1. Switch to a non-root `USER`.
+1. Switch to a non-root `USER` uid.
 
-        USER apache
+        USER 27
 
 1. Finish by adding the `CMD` instruction.
 
@@ -186,9 +187,10 @@ Now we are ready to build the images to test our Dockerfiles.
 
         $ sudo podman images
 
-1. Create the local directories for persistent storage.
+1. Create the local directories for persistent storage. Match the directory permissions we set in our Dockerfiles.
 
-        $ mkdir -p ~/workspace/mysql ~/workspace/uploads
+        $ mkdir -p ~/workspace/pv/mysql ~/workspace/pv/uploads
+        $ sudo chown -R 27:0 ~/workspace/pv
 
 1. Run the wordpress image first. See an explanation of all the `podman run` options we will be using below:
 
@@ -197,13 +199,22 @@ Now we are ready to build the images to test our Dockerfiles.
   * `-p <container_port>` to map the container port to the host port
 
 ```bash
-$ ls -lZd ~/workspace/uploads
-$ sudo podman run -d -p 8080 -v ~/workspace/uploads:/var/www/html/wp-content/uploads:z -e DB_ENV_DBUSER=user -e DB_ENV_DBPASS=mypassword -e DB_ENV_DBNAME=mydb -e DB_HOST=0.0.0.0 -e DB_PORT=3306 --name wordpress wordpress
+$ ls -lZd ~/workspace/pv/uploads
+$ sudo podman run -d -p 8080:8080 -v ~/workspace/pv/uploads:/var/www/html/wp-content/uploads:z -e DB_ENV_DBUSER=user -e DB_ENV_DBPASS=mypassword -e DB_ENV_DBNAME=mydb -e DB_HOST=0.0.0.0 -e DB_PORT=3306 --name wordpress wordpress
 ```
 Note: See the difference in SELinux context after running with a volume & :z.
 ```bash
-$ ls -lZd ~/workspace/uploads
+$ ls -lZd ~/workspace/pv/uploads
 $ sudo podman exec wordpress ps aux #we can also directly exec commands in the container
+```
+
+Check volume directory ownership inside the container
+```bash
+$ sudo podman exec wordpress stat --format="%U" /var/www/html/wp-content/uploads
+```
+
+Now we can check out how wordpress is doing
+```bash
 $ sudo podman logs wordpress
 $ sudo podman ps
 $ curl -L http://localhost:8080 #note we indicated the port to use in the run command above
@@ -215,18 +226,19 @@ $ curl -L http://localhost:8080 #note we indicated the port to use in the run co
 5. Test the Wordpress image to confirm connectivity. For the mariadb container we need to specify an additional option to make sure it is in the same "network" as the apache/wordpress container and not visible outside that container:
   * `--network=container:<alias>` to link to the wordpress container
 ```bash
-$ ls -lZd ~/workspace/mysql
-$ sudo podman run -d --network=container:wordpress -v ~/workspace/mysql:/var/lib/mysql:z -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
+$ ls -lZd ~/workspace/pv/mysql
+$ sudo podman run -d --network=container:wordpress -v ~/workspace/pv/mysql:/var/lib/mysql:z -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
 ```
 Note: See the difference in SELinux context after running w/ a volume & :z.
 ```bash
-$ ls -lZ ~/workspace/mysql
+$ ls -lZd ~/workspace/pv/mysql
+$ ls -lZ ~/workspace/pv/mysql
 $ sudo podman exec mariadb ps aux
 ```
 
 Check volume directory ownership inside the container
 ```bash
-$ sudo podman exec mariadb stat --format="%U" /var/lib/mysql/mysql
+$ sudo podman exec mariadb stat --format="%U" /var/lib/mysql
 ```
 
 Now we can check out how the database is doing
@@ -254,7 +266,7 @@ $ cat registry/Dockerfile
 Build & run the registry
 ```bash
 $ sudo podman build -t registry registry/
-$ sudo podman run --name registry -p 5000 -d registry
+$ sudo podman run --name registry -p 5000:5000 -d registry
 ```
 
 Confirm the registry is running.

--- a/labs/lab3/mariadb/Dockerfile.reference
+++ b/labs/lab3/mariadb/Dockerfile.reference
@@ -14,6 +14,6 @@ RUN chmod 755 /scripts/* && \
     chmod -R g=u ${MARIADB_DIRS}
 
 EXPOSE 3306
-VOLUME /var/lib/mysql /var/log/mariadb /run/mariadb
-USER mysql
+VOLUME /var/lib/mysql
+USER 27
 CMD ["/bin/bash", "/scripts/start.sh"]

--- a/labs/lab3/wordpress/Dockerfile.reference
+++ b/labs/lab3/wordpress/Dockerfile.reference
@@ -11,12 +11,13 @@ RUN chmod 755 /scripts/*
 COPY latest.tar.gz /latest.tar.gz
 RUN tar xvzf /latest.tar.gz -C /var/www/html --strip-components=1 && \
     rm /latest.tar.gz && \
+    usermod -u 27 apache && \
     sed -i 's/^Listen 80/Listen 8080/g' /etc/httpd/conf/httpd.conf && \
     APACHE_DIRS="/var/www/html /usr/share/httpd /var/log/httpd /run/httpd" && \
     chown -R apache:0 ${APACHE_DIRS} && \
     chmod -R g=u ${APACHE_DIRS}
 
 EXPOSE 8080
-VOLUME /var/www/html/wp-content/uploads /var/log/httpd /run/httpd
-USER apache
+VOLUME /var/www/html/wp-content/uploads
+USER 27
 CMD ["/bin/bash", "/scripts/start.sh"]

--- a/labs/lab4/chapter4.md
+++ b/labs/lab4/chapter4.md
@@ -11,9 +11,8 @@ Let's start with a little experimentation. I am sure you are all excited about y
 So, let's see what will happen. Launch the site:
 
 ```bash
-$ sudo podman run -d -p 8080 -v ~/workspace/uploads:/var/www/html/wp-content/uploads:z -e DB_ENV_DBUSER=user -e DB_ENV_DBPASS=mypassword -e DB_ENV_DBNAME=mydb -e DB_HOST=0.0.0.0 -e DB_PORT=3306 --name wordpress wordpress
-$ mkdir -p ~/workspace/mysql_logs ~/workspace/mysql_run
-$ sudo podman run -d --network=container:wordpress -v ~/workspace/mysql:/var/lib/mysql:z -v ~/workspace/mysql_logs:/var/log/mariadb:z -v ~/workspace/mysql_run:/run/mariadb:z -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
+$ sudo podman run -d -p 8080:8080 -v ~/workspace/pv/uploads:/var/www/html/wp-content/uploads:z -e DB_ENV_DBUSER=user -e DB_ENV_DBPASS=mypassword -e DB_ENV_DBNAME=mydb -e DB_HOST=0.0.0.0 -e DB_PORT=3306 --name wordpress wordpress
+$ sudo podman run -d --network=container:wordpress -v ~/workspace/pv/mysql:/var/lib/mysql:z -e DBUSER=user -e DBPASS=mypassword -e DBNAME=mydb --name mariadb mariadb
 ```
 
 Take a look at the site in your web browser on your machine using 
@@ -218,7 +217,7 @@ $ oc delete pod/mariadb pod/wordpress
 
 Verify they are terminating or are gone:
 ```bash
-$ oc get pods -w
+$ oc get pods
 ```
 **__NOTE:__** When you are finished watching the pods, just CTRL-C out.
 

--- a/labs/lab5/wordpress-template.yaml
+++ b/labs/lab5/wordpress-template.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     openshift.io/display-name: "WordPress MariaDB Example" 
     description: "An example WordPress application with a MariaDB database."
-    tags: "wordpress,php,mariadb,aws,loft"
+    tags: "wordpress,php,mariadb,summit"
     iconClass: "icon-php"
 objects:
 - apiVersion: v1
@@ -57,22 +57,8 @@ objects:
               - MYSQL_PWD="$DBPASS" mysql -h 127.0.0.1 -u $DBUSER -D $DBNAME
                 -e 'SELECT 1'
             timeoutSeconds: 2
-          volumeMounts:
-          - mountPath: /run/mariadb
-            name: mariadb-volume-1
-          - mountPath: /var/lib/mysql
-            name: mariadb-volume-2
-          - mountPath: /var/log/mariadb
-            name: mariadb-volume-3
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        volumes:
-        - emptyDir: {}
-          name: mariadb-volume-1
-        - emptyDir: {}
-          name: mariadb-volume-2
-        - emptyDir: {}
-          name: mariadb-volume-3
     triggers:
     - type: ConfigChange
 - apiVersion: v1
@@ -133,22 +119,8 @@ objects:
             tcpSocket:
               port: 8080
             timeoutSeconds: 1
-          volumeMounts:
-          - mountPath: /var/www/html/wp-content/uploads
-            name: wordpress-volume-1
-          - mountPath: /var/log/httpd
-            name: wordpress-volume-2
-          - mountPath: /run/httpd
-            name: wordpress-volume-3
         dnsPolicy: ClusterFirst
         restartPolicy: Always
-        volumes:
-        - emptyDir: {}
-          name: wordpress-volume-1
-        - emptyDir: {}
-          name: wordpress-volume-2
-        - emptyDir: {}
-          name: wordpress-volume-3
     triggers:
     - type: ConfigChange
 - apiVersion: v1


### PR DESCRIPTION
Removing unnecessary volumes from container run command and Dockerfiles. This simplifies things for the lab and runs better given the way podman is currently handling specified VOLUME(s).

Also changes the following:
 - `-p <host port>:<container port>` flag now being used
 - switching to using uid for USER in Dockerfile. this is a good practice w/ images targeted for a kube deployment... https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups (e.g. the MustRunAsNonRoot policy)